### PR TITLE
Fixed handle multiple winners in election results

### DIFF
--- a/client/src/Components/Screens/Election.js
+++ b/client/src/Components/Screens/Election.js
@@ -153,9 +153,9 @@ function Election() {
 				console.log('winner',winners);
 				for(let winner of winners){
 					console.log(Number(winner))
+					_winnerDetails.push(Number(winner))
 				}
-				_winnerDetails.push(Number(winners[0]))
-				console.log("set winner", Number(winners[0]))
+				console.log("set winner", _winnerDetails)
 
 				setWinnerDetails(_winnerDetails);
 				successtoast(id ,"Winner Details has been fetched");


### PR DESCRIPTION
Description:
This pull request fixes #19 

Previously, the application was logging all the winners but only storing the first winner in the _winnerDetails array. This could lead to incorrect results in elections where there are multiple winners.

Changes:
There is a for loop that now pushes all the winners in the _winnerDetails array. This is how the frontend looks like if there are multiple winners
<img width="1408" alt="image" src="https://github.com/AOSSIE-Org/Agora-Blockchain/assets/96711588/df31a3b8-4a3d-40b2-9361-0f0d0537be94">

