### PR TITLE
add user warning to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The application will automatically reload when you make changes to the source co
    ```bash
    npm install
    ```
+⚠️ Note: This is a monorepo. You must navigate into client/ or blockchain/ before running installation commands. Do not run npm install in the root directory.
 
 3. **Test the Contracts**:
 


### PR DESCRIPTION
# Description

Added a warning to the README.md to clarify that this project is a monorepo. New contributors often try running npm install in the root directory, which fails. This update explicitly instructs users to navigate into client/ or blockchain/ before installing dependencies.

Fixes # (issue)
Small doc fix, no issue created 

## Type of change

Please mark the options that are relevant.

- [ ] Updated UI/UX
- [ ] Improved the business logic of code
- [ ] Added new feature
- [x] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to clarify monorepo structure and setup procedures for new users. Now includes explicit step-by-step guidance directing users to run npm install only within individual project subdirectories (client/ or blockchain/) rather than at the repository root, preventing common setup issues and ensuring consistent development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->