### PR TITLE
feat: Add loading spinner to create election button

### DIFF
--- a/client/app/create/page.tsx
+++ b/client/app/create/page.tsx
@@ -231,8 +231,12 @@ const CreatePage: React.FC = () => {
           </div>
           <motion.button
             type="submit"
-            className="w-full py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-            whileHover={{ scale: 1.02 }}
+            disabled={isLoading}
+className={`w-full py-3 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white 
+    ${isLoading 
+      ? "bg-indigo-400 cursor-not-allowed opacity-70" 
+      : "bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-600 hover:to-purple-700" 
+    } focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500`}            whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
           >
             {isLoading ? <Loader/>: "Create Election"}

--- a/client/app/create/page.tsx
+++ b/client/app/create/page.tsx
@@ -13,9 +13,11 @@ import { sepolia } from "viem/chains";
 import { ArrowPathIcon , PlusIcon, TrashIcon} from "@heroicons/react/24/solid";
 import { useRouter } from "next/navigation";
 import ElectionInfoPopup from "../components/Modal/ElectionInfoPopup";
+import {Loader} from "rsuite";
 
 const CreatePage: React.FC = () => {
   const router = useRouter();
+  const [isLoading,setIsLoading] = useState<boolean>(false);
   const [selectedBallot, setSelectedBallot] = useState<number>(1);
   const { switchChain } = useSwitchChain();
   const { chain } = useAccount();
@@ -79,6 +81,7 @@ const CreatePage: React.FC = () => {
     }
   // passed candidates to the create election function 
     try {
+    setIsLoading(true);
       await writeContractAsync({
         address: ELECTION_FACTORY_ADDRESS,
         abi: ElectionFactory,
@@ -95,6 +98,9 @@ const CreatePage: React.FC = () => {
     } catch (error) {
       console.error("Error creating election:", error);
       toast.error(ErrorMessage(error));
+    }
+    finally{
+      setIsLoading(false);
     }
   };
 
@@ -229,7 +235,7 @@ const CreatePage: React.FC = () => {
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
           >
-            Create Election
+            {isLoading ? <Loader/>: "Create Election"}
           </motion.button>
         </form>
       </motion.div>


### PR DESCRIPTION
# Description
Added a loading state to the "Create Election" button to improve UX during transaction processing. Currently, the button remains static when clicked, leading to user confusion and potential double-submissions.

# Summary of the Change  : 
This PR introduces an `isLoading` state that:
1. Shows a spinner/loader animation.
2. Persists until the proccessing of election creation is either confirmed or fails (e.g., due to timeout).

Fixes #208 

## Type of change

- [x] Updated UI/UX


## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


https://github.com/user-attachments/assets/71d6cb0c-7223-4a66-974d-b0ececf4c55e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a loading indicator and disable state to the election creation submit button so users see a loader and cannot resubmit while the request is in progress.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->