### PR TITLE
Fixed error handling in fetchFileFromIPFS.ts

### DIFF
--- a/client/app/components/Fragment/CandidateDescription.tsx
+++ b/client/app/components/Fragment/CandidateDescription.tsx
@@ -6,14 +6,32 @@ const CandidateDescription = ({ IpfsHash }: { IpfsHash: String }) => {
     name: "",
     description: "",
   });
+  const [error, setError] = useState<string | null>(null);
+  
   const getIpfsFile = async () => {
-    const res = await fetchFileFromIPFS(IpfsHash);
-    setipfsFile(res);
+    try {
+      const res = await fetchFileFromIPFS(IpfsHash);
+      if (res && typeof res === 'object') {
+        setipfsFile(res);
+      }
+    } catch (err) {
+      // Handle error gracefully - set error state but don't crash the component
+      setError("Failed to load description");
+      console.error("Error fetching candidate description:", err);
+    }
   };
+  
   useEffect(() => {
-    ipfsFile.name === "" && getIpfsFile();
+    if (ipfsFile.name === "" && !error) {
+      getIpfsFile();
+    }
   }, []);
-  return <p>{ipfsFile?.description}</p>;
+  
+  if (error) {
+    return <p className="text-gray-400 italic">{error}</p>;
+  }
+  
+  return <p>{ipfsFile?.description || ""}</p>;
 };
 
 export default CandidateDescription;

--- a/client/app/helpers/fetchFileFromIPFS.ts
+++ b/client/app/helpers/fetchFileFromIPFS.ts
@@ -1,13 +1,31 @@
 const GATEWAY = "orange-confused-boar-516.mypinata.cloud";
-const JWT = process.env.NEXT_PUBLIC_PINATA_JWT;
 
+/**
+ * Fetches a file from IPFS using the provided CID (Content Identifier)
+ * @param CID - The IPFS Content Identifier (hash) of the file to fetch
+ * @returns Promise that resolves to the parsed JSON content of the file
+ * @throws Error if the fetch fails, response is not ok, or JSON parsing fails
+ */
 export async function fetchFileFromIPFS(CID: String) {
   const url = `https://${GATEWAY}/ipfs/${CID}`;
   try {
-    const request = await fetch(url);
-    const response = await request.json();
-    return response;
+    const response = await fetch(url);
+    
+    // Check if the HTTP response was successful (status 200-299)
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch file from IPFS: ${response.status} ${response.statusText}`
+      );
+    }
+    
+    // Parse JSON response
+    const data = await response.json();
+    return data;
   } catch (error) {
-    console.log(error);
+    // Re-throw the error with additional context if it's not already an Error
+    if (error instanceof Error) {
+      throw new Error(`Error fetching IPFS file (CID: ${CID}): ${error.message}`);
+    }
+    throw new Error(`Unknown error fetching IPFS file (CID: ${CID})`);
   }
 }


### PR DESCRIPTION
# Description
Silent failures: the function returned undefined on error, making failures hard to detect.
No HTTP status validation: non-200 responses were treated as success.
Poor error context: errors lacked useful information.
Unused variable: removed unused JWT.

Fixes #222 

How it was solved
Added HTTP status check:
   if (!response.ok) {     throw new Error(`Failed to fetch file from IPFS: ${response.status} ${response.statusText}`);   }
Throws on non-2xx responses.
Improved error handling:
Re-throws errors with context (CID included).
Handles both Error instances and unknown errors.
Added JSDoc:
Documents parameters, return value, and thrown errors.
Updated caller (CandidateDescription.tsx):
Wraps the call in try/catch.
Shows a user-friendly error message.
Prevents crashes when IPFS fetch fails.
Code cleanup:
Removed unused JWT.
Removed console.log.


## Type of change

Please mark the options that are relevant.

- [] Updated UI/UX
- [ ] Improved the business logic of code
- [ ] Added new feature
- [ ✅] Other

## Checklist:

- [✅ ] I have performed a self-review of my own code
- [✅ ] I have commented my code, particularly in hard-to-understand areas
- [ ✅] I have made corresponding changes to the documentation
- [ ✅] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for file retrieval operations with descriptive error messages displayed to users when operations fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->