### PR TITLE
docs: fix .env filename mismatch in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ git clone https://github.com/AOSSIE-Org/Agora-Blockchain
 
 2. **Set up Environment Variables**:
 
-   Create `.env.local` in the `blockchain` directory:
+   Create `.env` in the `blockchain` directory:
    ```
    PRIVATE_KEY=<your_private_key>
    RPC_URL_SEPOLIA=<your_sepolia_rpc_url>
@@ -53,7 +53,7 @@ git clone https://github.com/AOSSIE-Org/Agora-Blockchain
    ETHERSCAN_KEY=<your_etherscan_api_key>
    ```
 
-   Create `.env.local` in the `client` directory:
+   Create `.env` in the `client` directory:
    ```
    NEXT_PUBLIC_PINATA_JWT=<your_pinata_jwt>
    ```


### PR DESCRIPTION
## What

README currently instructs creating `.env.local` in both the `blockchain/` 
and `client/` directories, but `docker-compose.yml` looks for `.env`.

When following the Docker setup path, env vars never load and the 
application fails silently.

## Fix

Changed `.env.local` → `.env` in the Docker setup instructions to match 
what docker-compose.yml actually expects.

Fixes #234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable configuration file naming to align with project standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->