### PR TITLE
fix: implement time validation in createElection

### DIFF
--- a/blockchain/contracts/ElectionFactory.sol
+++ b/blockchain/contracts/ElectionFactory.sol
@@ -14,6 +14,8 @@ contract ElectionFactory is CCIPReceiver {
     error OwnerRestricted();
     error NotWhitelistedSender();
     error InvalidCandidatesLength();
+    error InvalidStartTime();
+    error InvalidEndTime();
 
     struct CCIPVote {
         address election;
@@ -61,7 +63,8 @@ contract ElectionFactory is CCIPReceiver {
         uint _resultType
     ) external {
         if (_candidates.length<2) revert InvalidCandidatesLength();
-        //add checks of time
+        if (_electionInfo.startTime <= block.timestamp) revert InvalidStartTime();
+        if (_electionInfo.endTime <= _electionInfo.startTime) revert InvalidEndTime();
         address electionAddress = Clones.clone(electionGenerator);
         address _ballot = ballotGenerator.generateBallot(
             _ballotType,


### PR DESCRIPTION
## Problem

`createElection()` in ElectionFactory.sol has a comment on line 64:
```solidity
//add checks of time
```

...but no actual time checks were implemented. This means:
- Elections can be created with `startTime` in the past (already active/ended on creation)
- Elections can be created with `endTime <= startTime` (zero-duration elections)

Both cases break the election lifecycle — voters either can't participate or the election is permanently in a broken state.

## Fix

Added two custom errors and corresponding checks:
```solidity
error InvalidStartTime();
error InvalidEndTime();

if (_electionInfo.startTime <= block.timestamp) revert InvalidStartTime();
if (_electionInfo.endTime <= _electionInfo.startTime) revert InvalidEndTime();
```

Custom errors are used (consistent with the existing error pattern in the contract) and are cheaper than require strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for election creation to prevent invalid time configurations. Elections cannot now be created with a start time in the past or an end time that doesn't exceed the start time, with specific error messages provided for each validation failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->