### PR TITLE
refactor(Election): Extract duplicated ballot init into ensureBallot modifier

### DIFF
--- a/blockchain/contracts/Election.sol
+++ b/blockchain/contracts/Election.sol
@@ -47,6 +47,14 @@ contract Election is Initializable {
         _;
     }
 
+    modifier ensureBallot() {
+        if (!ballotInitialized) {
+            ballot.init(candidates.length);
+            ballotInitialized = true;
+        }
+        _;
+    }
+
     ElectionInfo public electionInfo;
 
     address public factoryContract;
@@ -92,12 +100,8 @@ contract Election is Initializable {
         resultCalculator = IResultCalculator(_resultCalculator);
     }
 
-    function userVote(uint[] memory voteArr) external electionInactive {
+    function userVote(uint[] memory voteArr) external electionInactive ensureBallot {
         if (userVoted[msg.sender]) revert AlreadyVoted();
-        if (ballotInitialized == false) {
-            ballot.init(candidates.length);
-            ballotInitialized = true;
-        }
         ballot.vote(voteArr);
         userVoted[msg.sender] = true;
         totalVotes++;
@@ -106,12 +110,8 @@ contract Election is Initializable {
     function ccipVote(
         address user,
         uint[] memory _voteArr
-    ) external electionInactive {
+    ) external electionInactive ensureBallot {
         if (userVoted[user]) revert AlreadyVoted();
-        if (ballotInitialized == false) {
-            ballot.init(candidates.length);
-            ballotInitialized = true;
-        }
         if (msg.sender != factoryContract) revert OwnerPermissioned();
         userVoted[user] = true;
         ballot.vote(_voteArr);


### PR DESCRIPTION
## Summary

Eliminates a copy-pasted lazy-initialization block that existed identically in two functions, replacing it with a single `ensureBallot` modifier.

Closes #230

---

## Problem

Both `userVote()` and `ccipVote()` contained the identical 3-line block:

```solidity
if (ballotInitialized == false) {
    ballot.init(candidates.length);
    ballotInitialized = true;
}
```

This duplication means:
- Any future change to ballot initialization (e.g. different arguments, additional setup) must be applied in **both** places — easy to miss
- The intent ("ensure the ballot is ready before voting") is not named or encapsulated anywhere

---

## Fix

Extracted the block into a `ensureBallot` modifier and applied it to both functions:

```solidity
// New modifier
modifier ensureBallot() {
    if (!ballotInitialized) {
        ballot.init(candidates.length);
        ballotInitialized = true;
    }
    _;
}

// Before
function userVote(uint[] memory voteArr) external electionInactive {
    if (userVoted[msg.sender]) revert AlreadyVoted();
    if (ballotInitialized == false) {
        ballot.init(candidates.length);
        ballotInitialized = true;
    }
    ballot.vote(voteArr);
    ...
}

// After
function userVote(uint[] memory voteArr) external electionInactive ensureBallot {
    if (userVoted[msg.sender]) revert AlreadyVoted();
    ballot.vote(voteArr);
    ...
}
```

Same change applied to `ccipVote()`. Runtime behaviour is **identical** — only the structure changes.

---

## Files Changed

| File | Change |
|------|--------|
| `blockchain/contracts/Election.sol` | Added `ensureBallot` modifier; removed duplicated init blocks from `userVote()` and `ccipVote()` |

---

## Checklist

- [x] No behaviour change — pure structural refactor
- [x] Both `userVote` and `ccipVote` retain correct modifier order (`electionInactive` before `ensureBallot`)
- [x] No unrelated changes included
- [x] Branch created fresh from `upstream/main`