### PR TITLE
refactor: Replace inline auth checks with named modifiers (gas optimisation)

### DIFF
--- a/blockchain/contracts/Election.sol
+++ b/blockchain/contracts/Election.sol
@@ -47,6 +47,11 @@ contract Election is Initializable {
         _;
     }
 
+    modifier onlyFactory() {
+        if (msg.sender != factoryContract) revert OwnerPermissioned();
+        _;
+    }
+
     ElectionInfo public electionInfo;
 
     address public factoryContract;
@@ -106,13 +111,12 @@ contract Election is Initializable {
     function ccipVote(
         address user,
         uint[] memory _voteArr
-    ) external electionInactive {
+    ) external electionInactive onlyFactory {
         if (userVoted[user]) revert AlreadyVoted();
         if (ballotInitialized == false) {
             ballot.init(candidates.length);
             ballotInitialized = true;
         }
-        if (msg.sender != factoryContract) revert OwnerPermissioned();
         userVoted[user] = true;
         ballot.vote(_voteArr);
         totalVotes++;

--- a/blockchain/contracts/ElectionFactory.sol
+++ b/blockchain/contracts/ElectionFactory.sol
@@ -54,6 +54,11 @@ contract ElectionFactory is CCIPReceiver {
         _;
     }
 
+    modifier onlyElectionOwner(uint _electionId) {
+        if (electionOwner[_electionId] != msg.sender) revert OnlyOwner();
+        _;
+    }
+
     function createElection(
         Election.ElectionInfo memory _electionInfo,
         Election.Candidate[] memory _candidates, // add candidates separately due to separation of concerns 
@@ -82,8 +87,7 @@ contract ElectionFactory is CCIPReceiver {
         openBasedElections.push(address(election));
     }
 
-    function deleteElection(uint _electionId) external {
-        if (electionOwner[_electionId] != msg.sender) revert OnlyOwner();
+    function deleteElection(uint _electionId) external onlyElectionOwner(_electionId) {
         uint lastElement = openBasedElections.length - 1;
         if (_electionId != lastElement) {
             openBasedElections[_electionId] = openBasedElections[lastElement];


### PR DESCRIPTION
## Summary

Replaces two ad-hoc inline `if (...) revert` ownership checks inside function bodies with dedicated named modifiers, reducing gas and improving code clarity.

Closes #231

---

## Problem

Two contracts contained inline access-control checks embedded in function bodies instead of using modifiers:

**`Election.sol` — `ccipVote()`**
```solidity
function ccipVote(...) external electionInactive {
    if (userVoted[user]) revert AlreadyVoted();
    ...
    if (msg.sender != factoryContract) revert OwnerPermissioned(); // ← buried in body
    ...
}
```

**`ElectionFactory.sol` — `deleteElection()`**
```solidity
function deleteElection(uint _electionId) external {
    if (electionOwner[_electionId] != msg.sender) revert OnlyOwner(); // ← buried in body
    ...
}
```

Issues with this pattern:
1. **Gas**: The check runs after the function preamble and any preceding logic. Failing early at the modifier position is cheaper.
2. **Readability**: Access control intent is hidden inside the body; readers cannot see it from the function signature alone.

---

## Fix

**`Election.sol`** — added `onlyFactory` modifier, applied to `ccipVote()`:
```solidity
modifier onlyFactory() {
    if (msg.sender != factoryContract) revert OwnerPermissioned();
    _;
}

function ccipVote(...) external electionInactive onlyFactory { ... }
```

**`ElectionFactory.sol`** — added parameterised `onlyElectionOwner(uint)` modifier, applied to `deleteElection()`:
```solidity
modifier onlyElectionOwner(uint _electionId) {
    if (electionOwner[_electionId] != msg.sender) revert OnlyOwner();
    _;
}

function deleteElection(uint _electionId) external onlyElectionOwner(_electionId) { ... }
```

Both patterns follow the conventions already established in their respective contracts (`onlyOwner` in `Election.sol`, `onlyOwner` in `ElectionFactory.sol`).

---

## Files Changed

| File | Change |
|------|--------|
| `blockchain/contracts/Election.sol` | Added `onlyFactory` modifier; applied to `ccipVote()` |
| `blockchain/contracts/ElectionFactory.sol` | Added `onlyElectionOwner(uint)` modifier; applied to `deleteElection()` |

---

## Checklist

- [x] No behaviour change — access control logic is identical, only position moves to modifier
- [x] Both new modifiers follow naming and style conventions of existing modifiers in the same files
- [x] `ccipVote` modifier order (`electionInactive` before `onlyFactory`) is intentional — time-gate first, then auth
- [x] No unrelated changes included
- [x] Branch created fresh from `upstream/main`