### PR TITLE
fix(ElectionFactory): Key electionOwner on stable electionCount, fix deleteElection swap logic

### DIFF
--- a/blockchain/contracts/ElectionFactory.sol
+++ b/blockchain/contracts/ElectionFactory.sol
@@ -77,20 +77,23 @@ contract ElectionFactory is CCIPReceiver {
             msg.sender,
             resultCalculator
         );
+        electionOwner[electionCount] = msg.sender;
         electionCount++;
-        electionOwner[openBasedElections.length] = msg.sender;
         openBasedElections.push(address(election));
     }
 
     function deleteElection(uint _electionId) external {
         if (electionOwner[_electionId] != msg.sender) revert OnlyOwner();
-        uint lastElement = openBasedElections.length - 1;
-        if (_electionId != lastElement) {
-            openBasedElections[_electionId] = openBasedElections[lastElement];
-            electionOwner[_electionId] = electionOwner[lastElement];
+        uint lastIndex = openBasedElections.length - 1;
+        // Swap the last element into the slot of the election being deleted
+        for (uint i = 0; i <= lastIndex; i++) {
+            if (Election(openBasedElections[i]).electionId() == _electionId) {
+                openBasedElections[i] = openBasedElections[lastIndex];
+                break;
+            }
         }
         openBasedElections.pop();
-        delete electionOwner[lastElement];
+        delete electionOwner[_electionId];
     }
 
     function addWhitelistedContract(


### PR DESCRIPTION
## Summary

Fixes a logic bug where election ownership was tracked by **mutable array index** instead of the **stable monotonic `electionCount`**, causing `deleteElection`'s swap-and-pop to corrupt the ownership mapping.

Closes #248

---

## Problem

In `createElection()`:

```solidity
electionCount++;
electionOwner[openBasedElections.length] = msg.sender; // array index — unstable!
openBasedElections.push(address(election));
```

`electionCount` was already passed to `Election.initialize()` as the stable `electionId` stored on the clone — but the ownership mapping used `openBasedElections.length` (the array position) instead. These two identifiers diverge after any deletion.

`deleteElection()` uses swap-and-pop:

```solidity
uint lastElement = openBasedElections.length - 1;
if (_electionId != lastElement) {
    openBasedElections[_electionId] = openBasedElections[lastElement];
    electionOwner[_electionId] = electionOwner[lastElement]; // overwrites with swapped owner
}
openBasedElections.pop();
delete electionOwner[lastElement];
```

After a swap, the moved election's array index changes — but its `electionOwner` entry is keyed on the old index. Subsequent `deleteElection` calls using the correct `_electionId` from `Election.electionId()` will hit the wrong (or empty) ownership entry.

**Concrete scenario:**
1. Alice creates election A → `electionOwner[0] = Alice`, `A.electionId() = 0`
2. Bob creates election B → `electionOwner[1] = Bob`, `B.electionId() = 1`
3. Alice deletes election A (`_electionId = 0`): B is swapped to index 0, `electionOwner[0] = Bob`, `electionOwner[1]` deleted
4. Bob now calls `deleteElection(1)` (his stable ID from `B.electionId()`) → `electionOwner[1]` is empty → `OnlyOwner` revert — **Bob cannot delete his own election**

---

## Fix

**`createElection`** — record ownership against `electionCount` (the stable ID) before incrementing:

```solidity
// Before
electionCount++;
electionOwner[openBasedElections.length] = msg.sender;
openBasedElections.push(address(election));

// After
electionOwner[electionCount] = msg.sender;
electionCount++;
openBasedElections.push(address(election));
```

**`deleteElection`** — locate the target slot by comparing `Election.electionId()` (stable), swap the last element in, pop, and delete by stable ID. The swapped election's `electionOwner` entry is untouched — its stable ID has not changed.

```solidity
function deleteElection(uint _electionId) external {
    if (electionOwner[_electionId] != msg.sender) revert OnlyOwner();
    uint lastIndex = openBasedElections.length - 1;
    for (uint i = 0; i <= lastIndex; i++) {
        if (Election(openBasedElections[i]).electionId() == _electionId) {
            openBasedElections[i] = openBasedElections[lastIndex];
            break;
        }
    }
    openBasedElections.pop();
    delete electionOwner[_electionId];
}
```

---

## Files Changed

| File | Change |
|------|--------|
| `blockchain/contracts/ElectionFactory.sol` | Fixed ownership key in `createElection`; rewrote `deleteElection` swap to use stable IDs |

---

## Checklist

- [x] Root cause identified and documented in issue #248
- [x] `electionCount` is now the single source of truth for election identity throughout the factory
- [x] Swap logic in `deleteElection` uses `Election.electionId()` (public getter already present) to locate the correct slot
- [x] Ownership of swapped-in election is not touched — only the deleted election's entry is removed
- [x] No unrelated changes included
- [x] Branch created fresh from `upstream/main`