### PR TITLE
feat: add event emissions to Election contract

### DIFF
--- a/blockchain/contracts/Election.sol
+++ b/blockchain/contracts/Election.sol
@@ -13,6 +13,11 @@ contract Election is Initializable {
     error ElectionInactive();
     error InvalidCandidateID();
 
+    event Voted(address indexed voter, uint totalVotes);
+    event CandidateAdded(uint indexed candidateId, string name);
+    event CandidateRemoved(uint indexed candidateId);
+    event ResultsDeclared(uint[] winners);
+
     mapping(address user => bool isVoted) public userVoted;
 
     struct ElectionInfo {
@@ -101,6 +106,7 @@ contract Election is Initializable {
         ballot.vote(voteArr);
         userVoted[msg.sender] = true;
         totalVotes++;
+        emit Voted(msg.sender, totalVotes);
     }
 
     function ccipVote(
@@ -116,6 +122,7 @@ contract Election is Initializable {
         userVoted[user] = true;
         ballot.vote(_voteArr);
         totalVotes++;
+        emit Voted(user, totalVotes);
     }
 
     function addCandidate(
@@ -128,10 +135,12 @@ contract Election is Initializable {
             _description
         );
         candidates.push(newCandidate);
+        emit CandidateAdded(candidates.length - 1, _name);
     }
 
     function removeCandidate(uint _id) external onlyOwner electionStarted {
     if (_id >= candidates.length) revert InvalidCandidateID();
+    emit CandidateRemoved(_id);
     candidates[_id] = candidates[candidates.length - 1]; // Replace with last element
     candidates.pop(); 
 }
@@ -155,6 +164,7 @@ contract Election is Initializable {
         );
         winners = _winners;
         resultsDeclared = true;
+        emit ResultsDeclared(winners);
     }
 
     function getWinners() external view returns (uint[] memory) {


### PR DESCRIPTION
## Problem

`Election.sol` has zero `emit` statements. Every state-changing function (`userVote`, `ccipVote`, `addCandidate`, `removeCandidate`, `getResult`) mutates state silently.

This means:

1. The frontend cant use `watchContractEvent` hooks, it has to poll the RPC continuously
2. Off-chain indexers have no data to work with
3. The analytics dashboard mentioned in the GSoC 2026 roadmap cant be built without event logs to index

## Fix

Added 4 events and emitted them in the relevant functions:

```solidity
event Voted(address indexed voter, uint totalVotes);
event CandidateAdded(uint indexed candidateId, string name);
event CandidateRemoved(uint indexed candidateId);
event ResultsDeclared(uint[] winners);
```

`voter` and `candidateId` are indexed for efficient log filtering.

`totalVotes` is included in `Voted` so listeners can track participation rate without an extra RPC call.

`ResultsDeclared` emits after winners are calculated so the frontend can reactively display results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added voting activity events for improved transparency and real-time tracking of votes cast, candidates added or removed, and results declared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->