### PR TITLE
fix: use dynamic array size for IRV tie handling

### DIFF
--- a/blockchain/contracts/resultCalculators/IRVResult.sol
+++ b/blockchain/contracts/resultCalculators/IRVResult.sol
@@ -71,7 +71,7 @@ contract IRVResult is Errors, Candidatecheck {
                     }
                 }
                 // Return the array with the correct size
-                winners = new uint256[](2);
+                winners = new uint256[](count);
                 for (uint256 i = 0; i < count; i++) {
                     winners[i] = tiedWinners[i];
                 }


### PR DESCRIPTION
## Problem

In `IRVResult.sol`, the winners array on the tie path is allocated with a hardcoded size of 2:

```solidity
winners = new uint256[](2);
```

If 3 or more candidates are tied during an IRV elimination round, only the first 2 make it into the result array. The rest are silently dropped, which gives wrong election outcomes.

## Fix

Changed the allocation to use `count`, which is already computed in the same scope as the number of tied candidates:

```solidity
winners = new uint256[](count);
```

No logic changes, just the array size is corrected.

Found this while writing edge case tests for 3-way ties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accuracy of voting calculations for tied results. Previously, when multiple candidates received the same highest vote count, the system would return results in a fixed-size array regardless of the actual number of ties. It now correctly allocates appropriate space for all tied winners, ensuring accurate and precise election outcome reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->