### PR TITLE
fix: removeCandidate leaves stale candidateID on swapped candidate after swap-and-pop

### DIFF
--- a/blockchain/contracts/Election.sol
+++ b/blockchain/contracts/Election.sol
@@ -131,10 +131,11 @@ contract Election is Initializable {
     }
 
     function removeCandidate(uint _id) external onlyOwner electionStarted {
-    if (_id >= candidates.length) revert InvalidCandidateID();
-    candidates[_id] = candidates[candidates.length - 1]; // Replace with last element
-    candidates.pop(); 
-}
+        if (_id >= candidates.length) revert InvalidCandidateID();
+        candidates[_id] = candidates[candidates.length - 1];
+        candidates[_id].candidateID = _id; // fix stale ID after swap
+        candidates.pop();
+    }
 
     function getCandidateList() external view returns (Candidate[] memory) {
         return candidates;

--- a/blockchain/test/unit/Election.test.js
+++ b/blockchain/test/unit/Election.test.js
@@ -48,6 +48,67 @@ describe('Election', function () {
       candidates = await electionInstance.getCandidateList()
       expect(candidates.length).to.equal(3)
     })
+
+    it('Should update candidateID of moved candidate after removeCandidate', async function () {
+      const { electionFactory } = await loadFixture(deployElectionFactoryFixture)
+
+      const electionInfo = {
+        startTime: Math.floor(Date.now() / 1000) + 60,
+        endTime: Math.floor(Date.now() / 1000) + 3600,
+        name: 'Test Election',
+        description: 'This is a test election',
+      }
+      const initialCandidates = [
+        { candidateID: 0, name: 'Alice', description: 'A' },
+        { candidateID: 1, name: 'Bob', description: 'B' },
+        { candidateID: 2, name: 'Carol', description: 'C' },
+      ]
+
+      await electionFactory.createElection(electionInfo, initialCandidates, 1, 1)
+      const openElections = await electionFactory.getOpenElections()
+      const Election = await ethers.getContractFactory('Election')
+      const electionInstance = Election.attach(openElections[0])
+
+      // Remove index 0 — Carol (was index 2) swaps into index 0
+      await electionInstance.removeCandidate(0)
+
+      const candidates = await electionInstance.getCandidateList()
+      expect(candidates.length).to.equal(2)
+      // Carol is now at index 0; her candidateID must reflect that
+      expect(candidates[0].candidateID).to.equal(0n)
+      // Bob remains at index 1 unchanged
+      expect(candidates[1].candidateID).to.equal(1n)
+    })
+
+    it('Should keep all candidateIDs consistent after multiple removals', async function () {
+      const { electionFactory } = await loadFixture(deployElectionFactoryFixture)
+
+      const electionInfo = {
+        startTime: Math.floor(Date.now() / 1000) + 60,
+        endTime: Math.floor(Date.now() / 1000) + 3600,
+        name: 'Test Election',
+        description: 'This is a test election',
+      }
+      const initialCandidates = [
+        { candidateID: 0, name: 'A', description: '' },
+        { candidateID: 1, name: 'B', description: '' },
+        { candidateID: 2, name: 'C', description: '' },
+        { candidateID: 3, name: 'D', description: '' },
+      ]
+
+      await electionFactory.createElection(electionInfo, initialCandidates, 1, 1)
+      const openElections = await electionFactory.getOpenElections()
+      const Election = await ethers.getContractFactory('Election')
+      const electionInstance = Election.attach(openElections[0])
+
+      await electionInstance.removeCandidate(1) // D swaps into index 1
+      await electionInstance.removeCandidate(0) // remaining last swaps into index 0
+
+      const remaining = await electionInstance.getCandidateList()
+      for (let i = 0; i < remaining.length; i++) {
+        expect(remaining[i].candidateID).to.equal(BigInt(i))
+      }
+    })
   })
 
   describe('Voting Process', function () {


### PR DESCRIPTION
# Description

Include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

Fixes #252

## Type of change

Please mark the options that are relevant.

- [ ] Updated UI/UX
- [x] Improved the business logic of code
- [ ] Added new feature
- [ ] Other

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where candidate identifiers could become misaligned with their current position after removing a candidate from the election, ensuring data consistency across all remaining candidates.

* **Tests**
  * Added test coverage to validate candidate identifier consistency is maintained during removal operations, with scenarios covering single and multiple sequential removals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->