### PR TITLE
Add election creation validation and unit tests

### DIFF
--- a/blockchain/contracts/ElectionFactory.sol
+++ b/blockchain/contracts/ElectionFactory.sol
@@ -14,6 +14,8 @@ contract ElectionFactory is CCIPReceiver {
     error OwnerRestricted();
     error NotWhitelistedSender();
     error InvalidCandidatesLength();
+    error InvalidElectionTime();
+    error InvalidVotingConfig();
 
     struct CCIPVote {
         address election;
@@ -61,7 +63,19 @@ contract ElectionFactory is CCIPReceiver {
         uint _resultType
     ) external {
         if (_candidates.length<2) revert InvalidCandidatesLength();
-        //add checks of time
+        if (
+            _electionInfo.startTime >= _electionInfo.endTime ||
+            _electionInfo.endTime <= block.timestamp
+        ) revert InvalidElectionTime();
+
+        if (
+            _ballotType == 0 ||
+            _resultType == 0 ||
+            _ballotType > 8 ||
+            _resultType > 8 ||
+            _ballotType != _resultType
+        ) revert InvalidVotingConfig();
+
         address electionAddress = Clones.clone(electionGenerator);
         address _ballot = ballotGenerator.generateBallot(
             _ballotType,

--- a/blockchain/test/unit/Electionfactory.test.js
+++ b/blockchain/test/unit/Electionfactory.test.js
@@ -117,6 +117,78 @@ describe('ElectionFactory', function () {
         
 
     })
+    it('should revert if election time range is invalid', async function () {
+      const { electionFactory } = await loadFixture(deployElectionFactoryFixture)
+
+      const electionInfo = {
+        startTime: Math.floor(Date.now() / 1000) + 3600,
+        endTime: Math.floor(Date.now() / 1000) + 60,
+        name: 'invalid-time-election',
+        description: 'invalid election time range',
+      }
+      const initialCandidates = [
+        { candidateID: 1, name: 'candidate1', description: 'candidate1' },
+        { candidateID: 2, name: 'candidate2', description: 'candidate2s' },
+      ]
+
+      await expect(
+        electionFactory.createElection(electionInfo, initialCandidates, 1, 1)
+      ).to.be.revertedWithCustomError(electionFactory, 'InvalidElectionTime')
+    })
+    it('should revert if election end time is in the past', async function () {
+      const { electionFactory } = await loadFixture(deployElectionFactoryFixture)
+
+      const electionInfo = {
+        startTime: 1,
+        endTime: 2,
+        name: 'past-time-election',
+        description: 'end time already passed',
+      }
+      const initialCandidates = [
+        { candidateID: 1, name: 'candidate1', description: 'candidate1' },
+        { candidateID: 2, name: 'candidate2', description: 'candidate2s' },
+      ]
+
+      await expect(
+        electionFactory.createElection(electionInfo, initialCandidates, 1, 1)
+      ).to.be.revertedWithCustomError(electionFactory, 'InvalidElectionTime')
+    })
+    it('should revert if ballot and result types do not match', async function () {
+      const { electionFactory } = await loadFixture(deployElectionFactoryFixture)
+
+      const electionInfo = {
+        startTime: Math.floor(Date.now() / 1000) + 60,
+        endTime: Math.floor(Date.now() / 1000) + 3600,
+        name: 'invalid-types-election',
+        description: 'mismatched ballot and result types',
+      }
+      const initialCandidates = [
+        { candidateID: 1, name: 'candidate1', description: 'candidate1' },
+        { candidateID: 2, name: 'candidate2', description: 'candidate2s' },
+      ]
+
+      await expect(
+        electionFactory.createElection(electionInfo, initialCandidates, 1, 2)
+      ).to.be.revertedWithCustomError(electionFactory, 'InvalidVotingConfig')
+    })
+    it('should revert if ballot type is outside supported range', async function () {
+      const { electionFactory } = await loadFixture(deployElectionFactoryFixture)
+
+      const electionInfo = {
+        startTime: Math.floor(Date.now() / 1000) + 60,
+        endTime: Math.floor(Date.now() / 1000) + 3600,
+        name: 'invalid-ballot-type-election',
+        description: 'unsupported ballot type',
+      }
+      const initialCandidates = [
+        { candidateID: 1, name: 'candidate1', description: 'candidate1' },
+        { candidateID: 2, name: 'candidate2', description: 'candidate2s' },
+      ]
+
+      await expect(
+        electionFactory.createElection(electionInfo, initialCandidates, 9, 9)
+      ).to.be.revertedWithCustomError(electionFactory, 'InvalidVotingConfig')
+    })
     it('should delete the election ', async function () {
       const { electionFactory, election, owner } = await loadFixture(
         deployElectionFactoryFixture


### PR DESCRIPTION
# Description
Adds strict validation to election creation in the factory contract and introduces unit tests for the new validation paths.

Summary of changes:
- Added election input validation in blockchain/contracts/ElectionFactory.sol:
  - Rejects candidate list with fewer than 2 entries.
  - Rejects invalid election time windows (`startTime >= endTime`).
  - Rejects elections with `endTime` in the past.
  - Rejects invalid voting configuration (`ballotType/resultType` out of supported range or mismatched).
- Added/updated unit tests in blockchain/test/unit/Electionfactory.test.js:
  - Invalid time range revert case.
  - Past end-time revert case.
  - Ballot/result mismatch revert case.
  - Unsupported type revert case.

Dependencies:
- No new package dependencies added.

Fixes # (issue)
- Fixes # (issue)

## Type of change
- [ ] Updated UI/UX
- [x] Improved the business logic of code
- [ ] Added new feature
- [ ] Other

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced election creation validation with stricter checks for timing parameters and voting configuration.

* **Tests**
  * Added four new unit tests to verify proper handling of invalid election parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->