### PR TITLE
fix: preserve candidateID invariant when removing candidates

### DIFF
--- a/blockchain/contracts/Election.sol
+++ b/blockchain/contracts/Election.sol
@@ -131,10 +131,17 @@ contract Election is Initializable {
     }
 
     function removeCandidate(uint _id) external onlyOwner electionStarted {
-    if (_id >= candidates.length) revert InvalidCandidateID();
-    candidates[_id] = candidates[candidates.length - 1]; // Replace with last element
-    candidates.pop(); 
-}
+        if (_id >= candidates.length) revert InvalidCandidateID();
+
+        uint lastIndex = candidates.length - 1;
+
+        if (_id != lastIndex) {
+            candidates[_id] = candidates[lastIndex];
+            candidates[_id].candidateID = _id;
+        }
+
+        candidates.pop();
+    }
 
     function getCandidateList() external view returns (Candidate[] memory) {
         return candidates;

--- a/blockchain/test/unit/Election.test.js
+++ b/blockchain/test/unit/Election.test.js
@@ -48,6 +48,38 @@ describe('Election', function () {
       candidates = await electionInstance.getCandidateList()
       expect(candidates.length).to.equal(3)
     })
+
+    it('Should update the moved candidateID when removing a candidate', async function () {
+      const { electionFactory } = await loadFixture(deployElectionFactoryFixture)
+
+      const electionInfo = {
+        startTime: Math.floor(Date.now() / 1000) + 60,
+        endTime: Math.floor(Date.now() / 1000) + 3600,
+        name: 'Test Election',
+        description: 'This is a test election',
+      }
+      const initialCandidates = [
+        { candidateID: 10, name: 'Alice', description: 'Alice desc' },
+        { candidateID: 11, name: 'Bob', description: 'Bob desc' },
+        { candidateID: 12, name: 'Carol', description: 'Carol desc' },
+      ]
+
+      await electionFactory.createElection(electionInfo, initialCandidates, 1, 1)
+
+      const openElections = await electionFactory.getOpenElections()
+      const Election = await ethers.getContractFactory('Election')
+      const electionInstance = Election.attach(openElections[0])
+
+      await electionInstance.removeCandidate(0)
+
+      const candidates = await electionInstance.getCandidateList()
+
+      expect(candidates.length).to.equal(2)
+      expect(candidates[0].name).to.equal('Carol')
+      expect(candidates[0].candidateID).to.equal(0)
+      expect(candidates[1].name).to.equal('Bob')
+      expect(candidates[1].candidateID).to.equal(1)
+    })
   })
 
   describe('Voting Process', function () {

--- a/blockchain/test/unit/Election.test.js
+++ b/blockchain/test/unit/Election.test.js
@@ -59,9 +59,9 @@ describe('Election', function () {
         description: 'This is a test election',
       }
       const initialCandidates = [
-        { candidateID: 10, name: 'Alice', description: 'Alice desc' },
-        { candidateID: 11, name: 'Bob', description: 'Bob desc' },
-        { candidateID: 12, name: 'Carol', description: 'Carol desc' },
+        { candidateID: 0, name: 'Alice', description: 'Alice desc' },
+        { candidateID: 1, name: 'Bob', description: 'Bob desc' },
+        { candidateID: 2, name: 'Carol', description: 'Carol desc' },
       ]
 
       await electionFactory.createElection(electionInfo, initialCandidates, 1, 1)


### PR DESCRIPTION
## Summary
- update `Election.removeCandidate()` so the swapped candidate gets its new `candidateID` before the array is popped
- add a regression test that removes index `0` and verifies the remaining candidates keep consistent IDs

Fixes #252.

## Verification
- `PRIVATE_KEY=1111111111111111111111111111111111111111111111111111111111111111 RPC_URL_AMOY=http://127.0.0.1:8545 RPC_URL_SEPOLIA=http://127.0.0.1:8545 RPC_URL_FUJI=http://127.0.0.1:8545 RPC_URL_BSC=http://127.0.0.1:8545 ETHERSCAN_KEY=dummy npx hardhat test test/unit/Election.test.js`
- observed `6 passing`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved candidate removal to handle all positions safely and preserve list integrity.
  * Ensures remaining candidates are correctly reindexed so identifiers match their new positions.

* **Tests**
  * Added unit test verifying list length, order and identifier updates after removing a candidate.
  * Confirms behavior when removing the first, middle, or last candidate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->