### PR TITLE
fix: pin candidate descriptions during election creation

### DIFF
--- a/client/app/create/page.tsx
+++ b/client/app/create/page.tsx
@@ -13,6 +13,49 @@ import { sepolia } from "viem/chains";
 import { ArrowPathIcon , PlusIcon, TrashIcon} from "@heroicons/react/24/solid";
 import { useRouter } from "next/navigation";
 import ElectionInfoPopup from "../components/Modal/ElectionInfoPopup";
+import { pinJSONFile, unpinJSONFile } from "../helpers/pinToIPFS";
+
+interface Candidate {
+  name: string;
+  description: string;
+}
+
+interface PinnedCandidate {
+  candidateID: bigint;
+  name: string;
+  description: string;
+}
+
+const pinCandidateDescriptions = async (
+  candidates: Candidate[]
+): Promise<PinnedCandidate[]> => {
+  const pinnedCandidates: PinnedCandidate[] = [];
+
+  try {
+    for (let index = 0; index < candidates.length; index++) {
+      const candidate = candidates[index];
+      const response = await pinJSONFile({
+        pinataContent: {
+          name: candidate.name,
+          description: candidate.description,
+        },
+      });
+
+      pinnedCandidates.push({
+        candidateID: BigInt(index),
+        name: candidate.name,
+        description: response.IpfsHash,
+      });
+    }
+
+    return pinnedCandidates;
+  } catch (error) {
+    await Promise.allSettled(
+      pinnedCandidates.map((candidate) => unpinJSONFile(candidate.description))
+    );
+    throw error;
+  }
+};
 
 const CreatePage: React.FC = () => {
   const router = useRouter();
@@ -25,10 +68,6 @@ const CreatePage: React.FC = () => {
   const [candidates,setCandidates] = useState<Candidate[]>([])
   const changeChain = () => {
     switchChain({ chainId: sepolia.id });
-  }
-  interface Candidate {
-    name: string;
-    description: string;
   }
   const addCandidate = () => {
     setCandidates([...candidates, { name: "", description: "" }]);
@@ -77,15 +116,19 @@ const CreatePage: React.FC = () => {
       toast.error("please enter all candidate information or remove empty candidates.")
       return 
     }
-  // passed candidates to the create election function 
+
+    let pinnedCandidates: PinnedCandidate[] | undefined;
+
     try {
+      pinnedCandidates = await pinCandidateDescriptions(candidates);
+
       await writeContractAsync({
         address: ELECTION_FACTORY_ADDRESS,
         abi: ElectionFactory,
         functionName: "createElection",
         args: [
           { startTime: start, endTime: end, name, description }, // ElectionInfo object
-          candidates.map((c, index) => ({ candidateID: BigInt(index), name: c.name, description: c.description })), 
+          pinnedCandidates,
           ballotType,
           ballotType,
         ],
@@ -93,6 +136,12 @@ const CreatePage: React.FC = () => {
       toast.success("Election created successfully!");
       router.push("/");
     } catch (error) {
+      if (pinnedCandidates) {
+        await Promise.allSettled(
+          pinnedCandidates.map((candidate) => unpinJSONFile(candidate.description))
+        );
+      }
+
       console.error("Error creating election:", error);
       toast.error(ErrorMessage(error));
     }
@@ -147,7 +196,8 @@ const CreatePage: React.FC = () => {
             
             {candidates.length === 0 ? (
               <p className="text-gray-500 text-sm italic text-center py-4">
-                No candidates added yet. Click "Add Candidate" to begin adding candidates.
+                No candidates added yet. Click &quot;Add Candidate&quot; to begin
+                adding candidates.
               </p>
             ) : (
               candidates.map((candidate, index) => (

--- a/client/app/helpers/pinToIPFS.ts
+++ b/client/app/helpers/pinToIPFS.ts
@@ -1,6 +1,16 @@
 const JWT = process.env.NEXT_PUBLIC_PINATA_JWT;
 
-export const pinJSONFile = async (body: any) => {
+type PinJSONBody = {
+  pinataContent: Record<string, unknown>;
+};
+
+type PinJSONResponse = {
+  IpfsHash: string;
+};
+
+export const pinJSONFile = async (
+  body: PinJSONBody
+): Promise<PinJSONResponse> => {
   const options = {
     method: "POST",
     headers: {
@@ -15,8 +25,17 @@ export const pinJSONFile = async (body: any) => {
       "https://api.pinata.cloud/pinning/pinJSONToIPFS",
       options
     );
+
+    if (!response.ok) {
+      throw new Error(`Pinata pin request failed with status ${response.status}`);
+    }
+
     const data = await response.json();
-    console.log(data);
+
+    if (!data?.IpfsHash || typeof data.IpfsHash !== "string") {
+      throw new Error("Pinata pin request did not return a valid IpfsHash");
+    }
+
     return data;
   } catch (err) {
     console.error(err);
@@ -31,7 +50,16 @@ export const unpinJSONFile = async (CID: String) => {
   };
 
   try {
-    await fetch(`https://api.pinata.cloud/pinning/unpin/${CID}`, options);
+    const response = await fetch(
+      `https://api.pinata.cloud/pinning/unpin/${CID}`,
+      options
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Pinata unpin request failed with status ${response.status}`
+      );
+    }
   } catch (err) {
     console.error(err);
     throw err; // rethrow the error to be handled by the caller


### PR DESCRIPTION
## Summary
- pin candidate descriptions to IPFS before calling `createElection` so the create flow matches the post-creation `addCandidate` flow
- store the returned CID on-chain instead of raw description text, which keeps `CandidateDescription` compatible with newly created elections
- harden the Pinata helper with response validation and best-effort cleanup for failed pin/unpin flows

Fixes #240.

## Verification
- `npm run lint` in `client` passes; only pre-existing warnings remain in unrelated files
- `npx tsc --noEmit` in `client` still fails due to pre-existing type issues in unrelated files such as `app/components/Cards/ElectionDash.tsx`, `app/components/Cards/ElectionMini.tsx`, and `app/profile/page.tsx`