### PR TITLE
fix(blockchain): resolve candidate ID mismatch and circular dependency test failures

### DIFF
--- a/blockchain/contracts/Election.sol
+++ b/blockchain/contracts/Election.sol
@@ -131,10 +131,11 @@ contract Election is Initializable {
     }
 
     function removeCandidate(uint _id) external onlyOwner electionStarted {
-    if (_id >= candidates.length) revert InvalidCandidateID();
-    candidates[_id] = candidates[candidates.length - 1]; // Replace with last element
-    candidates.pop(); 
-}
+        if (_id >= candidates.length) revert InvalidCandidateID();
+        candidates[_id] = candidates[candidates.length - 1]; // Replace with last element
+        candidates[_id].candidateID = _id; // Update candidateID to reflect new position
+        candidates.pop(); 
+    }
 
     function getCandidateList() external view returns (Candidate[] memory) {
         return candidates;

--- a/blockchain/contracts/mocks/MockCCIPReceiverRouter.sol
+++ b/blockchain/contracts/mocks/MockCCIPReceiverRouter.sol
@@ -11,6 +11,10 @@ contract MockCCIPReceiverRouter {
         electionFactory = ElectionFactory(_electionFactory);
     }
 
+    function setElectionFactory(address _electionFactory) public {
+        electionFactory = ElectionFactory(_electionFactory);
+    }
+
     function sendMessage(
         bytes32 _messageId , 
         address _user , 

--- a/blockchain/test/ElectionFactory.test.js
+++ b/blockchain/test/ElectionFactory.test.js
@@ -10,10 +10,12 @@ describe("ElectionFactory", function () {
     description: "Test Description",
     startTime: Math.floor(Date.now() / 1000) + 3600,
     endTime: Math.floor(Date.now() / 1000) + 7200,
-    minVotes: 1,
-    maxVotes: 3,
-    options: ["Option 1", "Option 2", "Option 3"]
   };
+
+  const mockCandidates = [
+    { candidateID: 0, name: "Option 1", description: "Option 1" },
+    { candidateID: 1, name: "Option 2", description: "Option 2" }
+  ];
 
   beforeEach(async function () {
     [owner, user1, user2, router] = await ethers.getSigners();
@@ -35,7 +37,7 @@ describe("ElectionFactory", function () {
 
   describe("Election Creation", function () {
     it("Should create a new election", async function () {
-      await factory.createElection(mockElectionInfo, 0, 0);
+      await factory.createElection(mockElectionInfo, mockCandidates, 0, 0);
       expect(await factory.electionCount()).to.equal(1);
       
       const openElections = await factory.getOpenElections();
@@ -43,8 +45,8 @@ describe("ElectionFactory", function () {
     });
 
     it("Should allow multiple elections creation", async function () {
-      await factory.createElection(mockElectionInfo, 0, 0);
-      await factory.createElection(mockElectionInfo, 0, 0);
+      await factory.createElection(mockElectionInfo, mockCandidates, 0, 0);
+      await factory.createElection(mockElectionInfo, mockCandidates, 0, 0);
       
       expect(await factory.electionCount()).to.equal(2);
       const openElections = await factory.getOpenElections();
@@ -54,7 +56,7 @@ describe("ElectionFactory", function () {
 
   describe("Election Deletion", function () {
     beforeEach(async function () {
-      await factory.createElection(mockElectionInfo, 0, 0);
+      await factory.createElection(mockElectionInfo, mockCandidates, 0, 0);
     });
 
     it("Should allow owner to delete their election", async function () {

--- a/blockchain/test/fixtures/ElectionFactoryFixture.js
+++ b/blockchain/test/fixtures/ElectionFactoryFixture.js
@@ -26,10 +26,9 @@ async function deployElectionFactoryFixture() {
   const ballotGenerator = await BallotGenerator.deploy()
   const resultCalculator = await ResultCalculator.deploy()
   const election = await Election.deploy()
-  const electionFactory = await ElectionFactory.deploy(
-    '0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9' // changed the ccip router address to imitate the owner as the router and externally call ccip functions
-  )
-  const mockRouter = await MockCCIPReceiverRouter.deploy(electionFactory.target)
+  const mockRouter = await MockCCIPReceiverRouter.deploy(ethers.ZeroAddress)
+  const electionFactory = await ElectionFactory.deploy(mockRouter.target)
+  await mockRouter.setElectionFactory(electionFactory.target)
 
   return {
     electionFactory,

--- a/blockchain/test/unit/Election.test.js
+++ b/blockchain/test/unit/Election.test.js
@@ -47,6 +47,9 @@ describe('Election', function () {
       await electionInstance.removeCandidate(0)
       candidates = await electionInstance.getCandidateList()
       expect(candidates.length).to.equal(3)
+      for (let i = 0; i < candidates.length; i++) {
+        expect(candidates[i].candidateID).to.equal(i)
+      }
     })
   })
 

--- a/blockchain/test/unit/Election.test.js
+++ b/blockchain/test/unit/Election.test.js
@@ -48,7 +48,7 @@ describe('Election', function () {
       candidates = await electionInstance.getCandidateList()
       expect(candidates.length).to.equal(3)
       for (let i = 0; i < candidates.length; i++) {
-        expect(candidates[i].candidateID).to.equal(i)
+        expect(candidates[i].candidateID).to.equal(BigInt(i))
       }
     })
   })


### PR DESCRIPTION
# Description

This PR resolves issue #252 by correcting the candidate deletion logic and fixing the circular dependency in the test suite that was causing CCIP test failures.

Specifically:
- In `Election.sol`, when a candidate is removed via swap-and-pop, we update the `candidateID` of the moved candidate to match its new index, ensuring `candidates[i].candidateID == i` remains true.
- Add `setElectionFactory` to `MockCCIPReceiverRouter.sol` to allow updating the factory contract reference after deployment.
- Modify `ElectionFactoryFixture.js` to deploy `MockCCIPReceiverRouter` first and then link it to `ElectionFactory` via `setElectionFactory`, resolving the circular deployment dependency.
- Update `test/ElectionFactory.test.js` to pass 4 arguments to `createElection`.

Fixes #252

## Type of change

- [x] Improved the business logic of code

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed candidate IDs after removing a candidate, ensuring remaining candidates retain sequential IDs.

* **Tests**
  * Expanded election tests to verify candidate ID consistency.
  * Updated election creation scenarios and setup to reflect current candidate data requirements.
  * Improved test environment configuration for election factory and router interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->