### PR TITLE
fix(client): escape double quotes in app/create/page.tsx to resolve ESLint error

### DIFF
--- a/client/app/create/page.tsx
+++ b/client/app/create/page.tsx
@@ -147,7 +147,7 @@ const CreatePage: React.FC = () => {
             
             {candidates.length === 0 ? (
               <p className="text-gray-500 text-sm italic text-center py-4">
-                No candidates added yet. Click "Add Candidate" to begin adding candidates.
+                No candidates added yet. Click &quot;Add Candidate&quot; to begin adding candidates.
               </p>
             ) : (
               candidates.map((candidate, index) => (


### PR DESCRIPTION
# Description

This PR resolves issue #220 by escaping raw double quotes in `app/create/page.tsx` text content, resolving a blocking ESLint `no-unescaped-entities` error.

Fixes #220

## Type of change

- [x] Improved the business logic of code

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the display of quotation marks in the empty-candidate placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->